### PR TITLE
Upgrade to 8.13.0, fix two CI failures

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -2,10 +2,10 @@ class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server (with rustls)"
   homepage "https://curl.se"
   # Don't forget to update both instances of the version in the GitHub mirror URL.
-  url "https://curl.se/download/curl-8.12.1.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-8_12_1/curl-8.12.1.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/curl-8.12.1.tar.bz2"
-  sha256 "18681d84e2791183e0e5e4650ccb2a080c1f3a4e57ed2fbc2457228579d68269"
+  url "https://curl.se/download/curl-8.13.0.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-8_13_0/curl-8.13.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/curl-8.13.0.tar.bz2"
+  sha256 "e0d20499260760f9865cb6308928223f4e5128910310c025112f592a168e1473"
   license "curl"
 
   livecheck do

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -36,6 +36,13 @@ class Curl < Formula
   uses_from_macos "krb5"
   uses_from_macos "zlib"
 
+  # TODO(XXX): remove once upstream fix is in a release.
+  # https://github.com/curl/curl/pull/16995
+  patch do
+    url "https://github.com/curl/curl/commit/eeed87f0563d3ca73ff53813418d1f9f03c81fe5.patch?full_index=1"
+    sha256 "f7461a8042ca8ef86492338458ccd79ee286d17773487513928d7ed6ae25818c"
+  end
+
   def install
     tag_name = "curl-#{version.to_s.tr(".", "_")}"
     if build.stable? && stable.mirrors.grep(/github\.com/).first.exclude?(tag_name)

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -85,7 +85,7 @@ class Curl < Formula
     filename.verify_checksum stable.checksum
 
     system libexec/"mk-ca-bundle.pl", "test.pem"
-    assert_predicate testpath/"test.pem", :exist?
-    assert_predicate testpath/"certdata.txt", :exist?
+    assert_path_exists testpath/"test.pem"
+    assert_path_exists testpath/"certdata.txt"
   end
 end


### PR DESCRIPTION
This bundles together the commit from @magnuswatn to upgrade to curl 8.13.0, the style fix commit from @kpcyrd and a patch commit I added to fix a `mk-ca-bundle.pl` failure. This should fix CI across the board.

Replaces https://github.com/rustls/homebrew-tap/pull/9, https://github.com/rustls/homebrew-tap/pull/10
